### PR TITLE
Fix ConvexHullGraham sorting and remove numpy dependency

### DIFF
--- a/ConvexHull.py
+++ b/ConvexHull.py
@@ -5,7 +5,7 @@ Created on Fri Apr 16 2021
 @author: Michael Lin
 """
 from LineIntersectionChecker import Point, orientation
-import numpy as np
+import math
 import copy
 # Jarvis Algorithm
 
@@ -139,7 +139,10 @@ class ConvexHullGraham:
 
         # Sort the rest of the point list based on angle and distance
         starting_point = point_list[0]
-        point_list[1:] = sorted(point_list[1:], key=lambda p1, p2: polar_comp(p1, p2, starting_point))
+        point_list[1:] = sorted(
+            point_list[1:],
+            key=lambda p: sort_by_angle_and_distance(starting_point, p)
+        )
 
         # After sorted, update point list to remove points that are close and have the same angle
         updated_point_list = self.update_point_list(point_list)
@@ -189,7 +192,7 @@ def distance(point1, point2):
     """
     x1, y1 = point1.x, point1.y
     x2, y2 = point2.x, point2.y
-    return np.sqrt((y2 - y1) * (y2 - y1) + (x2 - x1) * (x2 - x1))
+    return math.sqrt((y2 - y1) * (y2 - y1) + (x2 - x1) * (x2 - x1))
 
 
 def main():


### PR DESCRIPTION
## Summary
- drop the numpy import and use `math.sqrt`
- fix sorting in `ConvexHullGraham.convex_hull` to use `sort_by_angle_and_distance`

## Testing
- `python -m unittest discover -v`